### PR TITLE
Fix getCOM bug

### DIFF
--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -378,7 +378,7 @@ void setPosRot(Body *b, glm::dvec3 pos, glm::dmat3 rot)
 
 glm::dvec3 getCOM(Body *body) {
     btVector3 COM = getRigidBody(body)->getCenterOfMassTransform().getOrigin();
-    return glm::dvec3(COM.getX(), COM.getY(), COM.getX());
+    return glm::dvec3(COM.getX(), COM.getY(), COM.getZ());
 }
 
 double GetMass(Body *body) {


### PR DESCRIPTION
## Summary
- fix incorrect axis usage when retrieving COM

## Testing
- `make` *(fails: glm missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f7d54e39c832095618c81e23fb59a